### PR TITLE
Enable saving extracted highlighted words of PDF in a yaml

### DIFF
--- a/src/cmdict/run_script.py
+++ b/src/cmdict/run_script.py
@@ -8,6 +8,7 @@ from colorama import Fore, Style
 from colorama import init as _init_colorama
 import requests
 from tqdm import tqdm
+import yaml
 
 from cmdict.ecdict_connector import ecdict_engine
 from cmdict.pdf_tools import extract_words
@@ -107,16 +108,30 @@ def scan(txt_path):
 
 @cli.command()
 @click.argument("pdf_path", type=click.Path(exists=True))
-@click.option("--color", default="yellow", show_default=True)
-def extract(pdf_path, color):
+@click.option(
+    "--color",
+    default="yellow",
+    help="Which color the highlights are in.",
+    show_default=True,
+)
+@click.option(
+    "--save", "-s", is_flag=True, help="Whether to save extracted words."
+)
+def extract(pdf_path, color, save):
     """Extract highlighted words with specified color in a PDF file.
 
     Args:
         pdf_path (str): path to the PDF file.
         color (str): three numbers ranging between 0 and 1.
+        save (bool): if extracted words will be saved in yaml file.
     """
     if _valid_db_exists():
         words = extract_words(pdf_path, color)
+
+        if save:
+            with open(_db_dir + "/extraction.yaml", "w") as f:
+                yaml.safe_dump(list(words), f)
+
         for i, word in enumerate(words):
             _echo_item(word, ecdict_engine.query(word))
     else:

--- a/tests/cmdict/test_run_script.py
+++ b/tests/cmdict/test_run_script.py
@@ -1,7 +1,15 @@
 """Test functions for seaching in command line."""
+import os
+import pathlib
+
 from click.testing import CliRunner
+import yaml
 
 from cmdict.run_script import cli, extract, scan, search
+
+_path_yaml = os.path.join(
+    str(pathlib.Path(__file__).parents[2]), "src/cmdict/data/extraction.yaml"
+)
 
 
 def test_cli():
@@ -58,6 +66,33 @@ def test_cli_extract_from_pdf_with_hyphen_broken_fix():
     res = CliRunner().invoke(extract, [sample_pdf, "--color=green"])
     expected = ["producer", "ensure", "optimal", "production"]
     assert res.exit_code == 0 and all(word in res.output for word in expected)
+
+
+def test_cli_extract_from_pdf_with_save():
+    """Test cli extract words from PDF and save it in a yaml file."""
+
+    def _read_yaml(path):
+        """Read the yaml file and return content in a list.
+
+        Args:
+            path (str): to the yaml file.
+
+        Returns:
+            List[str]: all words in the yaml file.
+        """
+        with open(path, "r") as f:
+            try:
+                hist = yaml.safe_load(f)
+            except yaml.YAMLError as exc:
+                print(exc)
+        return hist
+
+    sample_pdf = "./tests/sample-1.pdf"
+    res = CliRunner().invoke(extract, [sample_pdf, "--color=green", "-s"])
+    expected = ["producer", "ensure", "optimal", "production"]
+    assert res.exit_code == 0 and all(
+        word in _read_yaml(_path_yaml) for word in expected
+    )
 
 
 def test_cli_scan():


### PR DESCRIPTION
- `run_script.py::_echo_item` tells whether the word is found in the database. But the feature is not used anywhere, yet.
-   New option, "--save" or "-s" to save all extracted highlighted words in a yaml, no matter whether these words are found in the database.
- Closing #43.